### PR TITLE
Feature/36 drag and drop

### DIFF
--- a/client/src/components/App/App.scss
+++ b/client/src/components/App/App.scss
@@ -9,3 +9,13 @@
   overflow-x: auto;
   padding: 15px;
 }
+
+.float-item {
+  position: fixed;
+  padding: 0;
+  margin: 0;
+  transition: transform 200ms ease, box-shadow 200ms ease;
+  transform: scale(1.03);
+  box-shadow: 0 30px 60px rgba(0, 0, 0, 0.3);
+  z-index: 999;
+}

--- a/client/src/components/App/App.ts
+++ b/client/src/components/App/App.ts
@@ -46,6 +46,7 @@ class App extends Component<IProps, IState> {
       { className: 'container' },
       new Header({ title: 'TODO 서비스', onToggleSideMenu }),
       new DashBoard({ userId: 1 }, { kanbans: [] }),
+      div({ className: 'float-item' }),
       new SideBar(
         {
           visible: this.getState('menuVisible'),

--- a/client/src/components/Column/Column.scss
+++ b/client/src/components/Column/Column.scss
@@ -1,7 +1,7 @@
 @use '../../styles/_definitions.scss';
 
 .column-container {
-  min-width: 300px;
+  min-width: 340px;
   display: inline-block;
   height: 100%;
 

--- a/client/src/components/Column/Column.ts
+++ b/client/src/components/Column/Column.ts
@@ -44,8 +44,10 @@ class Column extends Component<IProps, IState> {
   render() {
     const { name, userName, items, id } = this.props
 
-    return li(
-      { className: 'column-container' },
+    return div(
+      {
+        className: 'column-container',
+      },
       div(
         { className: 'column-wrapper' },
         div(
@@ -77,7 +79,10 @@ class Column extends Component<IProps, IState> {
               toggleAddItemInput: () => this.onToggleInputBox(),
             })
           : null,
-        ul({}, ...this.renderItems())
+        ul(
+          { className: 'column-items-container', id: `column-${id}` },
+          ...this.renderItems()
+        )
       )
     )
   }

--- a/client/src/components/TodoItem/TodoItem.scss
+++ b/client/src/components/TodoItem/TodoItem.scss
@@ -2,12 +2,17 @@
 
 .item-wrapper {
   position: relative;
-  min-height: 60px;
+  width: 300px;
+  text-overflow: ellipsis;
+  overflow: hidden;
+  height: 70px;
   padding: 15px;
   background-color: white;
   border-radius: 7px;
   box-shadow: 5px 5px 5px rgba(100, 100, 100, 0.1);
   cursor: pointer;
+  list-style: none;
+  // transition: all 1000ms ease;
 
   .item-top {
     display: flex;
@@ -33,8 +38,6 @@
     position: absolute;
     right: 15px;
     bottom: 5px;
-    // margin-top: 30px;
-    // margin-left: 35px;
     font-weight: 300;
     color: lightgray;
 
@@ -44,6 +47,19 @@
   }
 }
 
+.temp {
+  opacity: 0.5;
+}
+
 .item-wrapper + .item-wrapper {
   margin-top: 15px;
+}
+
+.item-wrapper.overlapped {
+  opacity: 0.5;
+  // transform: translateY(-80);
+}
+
+.column-items-container.overlapped {
+  box-shadow: 0px 0px 10px rgba(100, 100, 100, 0.3);
 }

--- a/client/src/components/TodoItem/TodoItem.ts
+++ b/client/src/components/TodoItem/TodoItem.ts
@@ -15,7 +15,10 @@ class TodoItem extends Component<IProps, IState> {
     this.init()
   }
 
-  onMouseDown(e: Event) {}
+  onMouseDown(e: Event) {
+    const element = e.target as HTMLElement
+    // element.closest('')
+  }
 
   render() {
     const { author, content, id } = this.props

--- a/client/src/index.ts
+++ b/client/src/index.ts
@@ -1,5 +1,6 @@
 import { App } from './components/App'
 import { domRenderer } from './utils/wooact'
 import './styles/reset.scss'
+import './utils/dragAndDrop'
 
 domRenderer(new App({}, { menuVisible: false }), document.querySelector('#App'))

--- a/client/src/utils/dragAndDrop.ts
+++ b/client/src/utils/dragAndDrop.ts
@@ -1,13 +1,25 @@
 import { transform } from 'typescript'
 
+const position = { x: 0, y: 0 }
 let clicked: boolean = false
 let target: HTMLElement = null
 let cloned = null
-const position = { x: 0, y: 0 }
 let overlappedElement = { item: null, column: null }
+let isOnTop: boolean = false
 
-let originalLeft = null
-let originalTop = null
+const setFloatingItem = (e: MouseEvent, init: boolean = false) => {
+  const { pageX, pageY } = e
+
+  const floatingItem = document.querySelector('.float-item') as HTMLElement
+
+  floatingItem.style.left = pageX + position.x + 'px'
+  floatingItem.style.top = pageY + position.y + 'px'
+
+  if (init) {
+    floatingItem.appendChild(cloned)
+  }
+  return floatingItem
+}
 
 const onMouseDown = (e: MouseEvent) => {
   target = (e.target as HTMLElement).closest('.item-wrapper')
@@ -24,12 +36,7 @@ const onMouseDown = (e: MouseEvent) => {
   position.x = target.offsetLeft - pageX
   position.y = target.offsetTop - pageY
 
-  const floatingItem = document.querySelector('.float-item') as HTMLElement
-
-  floatingItem.style.left = e.pageX + position.x + 'px'
-  floatingItem.style.top = e.pageY + position.y + 'px'
-  cloned.classList.add('item-wrapper')
-  floatingItem.appendChild(cloned)
+  setFloatingItem(e, true)
 }
 
 const onMouseUp = (e: MouseEvent) => {
@@ -39,8 +46,12 @@ const onMouseUp = (e: MouseEvent) => {
   const { pageX, pageY } = e
 
   // if has something overlapped
-  swapIfOverlappedWithItem()
-  moveToOtherColumn()
+  const isItemSwapped = swapIfOverlappedWithItem()
+  const isMovedToOhterColumn = moveToOtherColumn()
+
+  if (isItemSwapped || isMovedToOhterColumn) {
+    // update Query
+  }
 
   resetToDefault()
 }
@@ -50,15 +61,8 @@ const onMouseMove = (e: MouseEvent) => {
     return
   }
 
-  const floatingItem = document.querySelector('.float-item') as HTMLElement
+  setFloatingItem(e)
 
-  const { pageX, pageY } = e
-  floatingItem.style.left = pageX + position.x + 'px'
-  floatingItem.style.top = pageY + position.y + 'px'
-
-  //   document
-  //     .querySelectorAll('.item-wrapper.overlapped')
-  //     .forEach((item) => item.classList.remove('overlapped'))
   resetOverlapped()
   findOverlappedItem(e)
   findOverlappedColumn(e)
@@ -72,43 +76,37 @@ const onMouseMove = (e: MouseEvent) => {
   //   }
 }
 
-const resetOverlapped = () => {
-  if (overlappedElement.item) {
-    overlappedElement.item.classList.remove('overlapped')
-    overlappedElement.item = null
-  }
-  if (overlappedElement.column) {
-    overlappedElement.column.classList.remove('overlapped')
-    overlappedElement.column = null
-  }
-}
-
 const swapIfOverlappedWithItem = () => {
   if (!overlappedElement.item) {
-    return
+    return false
   }
-  const overlappedPostion = overlappedElement.item.getBoundingClientRect()
-  const targetPostion = target.getBoundingClientRect()
 
-  if (overlappedPostion.top < targetPostion.top) {
-    overlappedElement.item.insertAdjacentElement('beforebegin', target)
-  } else {
-    overlappedElement.item.insertAdjacentElement('afterend', target)
-  }
+  const parent = (overlappedElement.column ||
+    target.parentElement) as HTMLElement
+  parent.insertBefore(target, overlappedElement.item)
+  //   if (overlappedPostion.top < targetPostion.top) {
+  //     overlappedElement.item.insertAdjacentElement('beforebegin', target)
+  //   } else {
+  //     overlappedElement.item.insertAdjacentElement('afterend', target)
+  //   }
+
+  return true
 }
 
 const moveToOtherColumn = () => {
   if (overlappedElement.item || !overlappedElement.column) {
-    return
+    return false
   }
-
-  const container = document.querySelector('.column-items-container')
-  console.log(container)
-  container.appendChild(target)
+  console.log('added to column')
+  //   const container = document.querySelector('.column-items-container')
+  //   console.log(container)
+  overlappedElement.column.appendChild(target)
+  return true
 }
 
 const findOverlappedItem = (e: MouseEvent) => {
-  const elements = document.elementsFromPoint(e.pageX, e.pageY)
+  const { pageX, pageY } = e
+  const elements = document.elementsFromPoint(e.pageX, e.pageY) as HTMLElement[]
   const [overlappedItem, ..._] = elements.filter(
     (item) =>
       item !== cloned &&
@@ -127,19 +125,27 @@ const findOverlappedItem = (e: MouseEvent) => {
 const findOverlappedColumn = (e: MouseEvent) => {
   const elements = document.elementsFromPoint(e.pageX, e.pageY)
   const [overlappedColumn, ..._] = elements.filter(
-    (item) =>
-      item.classList.contains('column-container') &&
-      item.id !== target.parentElement.id
+    (item) => item.classList.contains('column-items-container') //&&item.id !== target.parentElement.id
   )
 
   overlappedElement.column = overlappedColumn
   if (!overlappedColumn) {
     return
   }
+  overlappedElement.column.classList.add('overlapped')
+}
 
-  console.log(`has overlapped column`)
-
-  //   overlapped.classList.add('overlapped')
+const resetOverlapped = () => {
+  if (overlappedElement.item) {
+    overlappedElement.item.style = null
+    overlappedElement.item.classList.remove('overlapped')
+    overlappedElement.item = null
+  }
+  if (overlappedElement.column) {
+    overlappedElement.column.style = null
+    overlappedElement.column.classList.remove('overlapped')
+    overlappedElement.column = null
+  }
 }
 
 const resetToDefault = () => {
@@ -153,10 +159,10 @@ const resetToDefault = () => {
 
   target = null
   cloned = null
-  originalLeft = null
-  originalTop = null
+  isOnTop = null
   resetOverlapped()
 }
+
 window.addEventListener('pointerdown', onMouseDown)
 window.addEventListener('pointerup', onMouseUp)
 window.addEventListener('pointermove', onMouseMove)

--- a/client/src/utils/dragAndDrop.ts
+++ b/client/src/utils/dragAndDrop.ts
@@ -1,0 +1,162 @@
+import { transform } from 'typescript'
+
+let clicked: boolean = false
+let target: HTMLElement = null
+let cloned = null
+const position = { x: 0, y: 0 }
+let overlappedElement = { item: null, column: null }
+
+let originalLeft = null
+let originalTop = null
+
+const onMouseDown = (e: MouseEvent) => {
+  target = (e.target as HTMLElement).closest('.item-wrapper')
+  if (!target) {
+    return
+  }
+
+  clicked = true
+
+  cloned = target.cloneNode(true)
+  target.classList.add('temp')
+  const { pageX, pageY } = e
+
+  position.x = target.offsetLeft - pageX
+  position.y = target.offsetTop - pageY
+
+  const floatingItem = document.querySelector('.float-item') as HTMLElement
+
+  floatingItem.style.left = e.pageX + position.x + 'px'
+  floatingItem.style.top = e.pageY + position.y + 'px'
+  cloned.classList.add('item-wrapper')
+  floatingItem.appendChild(cloned)
+}
+
+const onMouseUp = (e: MouseEvent) => {
+  if (!clicked) {
+    return
+  }
+  const { pageX, pageY } = e
+
+  // if has something overlapped
+  swapIfOverlappedWithItem()
+  moveToOtherColumn()
+
+  resetToDefault()
+}
+
+const onMouseMove = (e: MouseEvent) => {
+  if (!clicked) {
+    return
+  }
+
+  const floatingItem = document.querySelector('.float-item') as HTMLElement
+
+  const { pageX, pageY } = e
+  floatingItem.style.left = pageX + position.x + 'px'
+  floatingItem.style.top = pageY + position.y + 'px'
+
+  //   document
+  //     .querySelectorAll('.item-wrapper.overlapped')
+  //     .forEach((item) => item.classList.remove('overlapped'))
+  resetOverlapped()
+  findOverlappedItem(e)
+  findOverlappedColumn(e)
+
+  // swap element
+  //   const overlappedPostion = overlapped.getBoundingClientRect()
+  //   console.log(overlappedPostion.top, pageX)
+  //   if (overlappedPostion.top > pageX) {
+  //     ;(overlapped as HTMLElement).style.top = overlappedPostion.top + 30 + 'px'
+  //     target.style.top = target.style.top - 30 + 'px'
+  //   }
+}
+
+const resetOverlapped = () => {
+  if (overlappedElement.item) {
+    overlappedElement.item.classList.remove('overlapped')
+    overlappedElement.item = null
+  }
+  if (overlappedElement.column) {
+    overlappedElement.column.classList.remove('overlapped')
+    overlappedElement.column = null
+  }
+}
+
+const swapIfOverlappedWithItem = () => {
+  if (!overlappedElement.item) {
+    return
+  }
+  const overlappedPostion = overlappedElement.item.getBoundingClientRect()
+  const targetPostion = target.getBoundingClientRect()
+
+  if (overlappedPostion.top < targetPostion.top) {
+    overlappedElement.item.insertAdjacentElement('beforebegin', target)
+  } else {
+    overlappedElement.item.insertAdjacentElement('afterend', target)
+  }
+}
+
+const moveToOtherColumn = () => {
+  if (overlappedElement.item || !overlappedElement.column) {
+    return
+  }
+
+  const container = document.querySelector('.column-items-container')
+  console.log(container)
+  container.appendChild(target)
+}
+
+const findOverlappedItem = (e: MouseEvent) => {
+  const elements = document.elementsFromPoint(e.pageX, e.pageY)
+  const [overlappedItem, ..._] = elements.filter(
+    (item) =>
+      item !== cloned &&
+      item !== target &&
+      item.classList.contains('item-wrapper')
+  )
+
+  overlappedElement.item = overlappedItem
+  if (!overlappedElement.item) {
+    return
+  }
+
+  overlappedElement.item.classList.add('overlapped')
+}
+
+const findOverlappedColumn = (e: MouseEvent) => {
+  const elements = document.elementsFromPoint(e.pageX, e.pageY)
+  const [overlappedColumn, ..._] = elements.filter(
+    (item) =>
+      item.classList.contains('column-container') &&
+      item.id !== target.parentElement.id
+  )
+
+  overlappedElement.column = overlappedColumn
+  if (!overlappedColumn) {
+    return
+  }
+
+  console.log(`has overlapped column`)
+
+  //   overlapped.classList.add('overlapped')
+}
+
+const resetToDefault = () => {
+  clicked = false
+  if (target) {
+    target.classList.remove('temp')
+  }
+  if (cloned) {
+    cloned.remove()
+  }
+
+  target = null
+  cloned = null
+  originalLeft = null
+  originalTop = null
+  resetOverlapped()
+}
+window.addEventListener('pointerdown', onMouseDown)
+window.addEventListener('pointerup', onMouseUp)
+window.addEventListener('pointermove', onMouseMove)


### PR DESCRIPTION
## simple drag and drop

`elementsFromPoint` api를 이용해 마우스 이벤트의 위치값을 이용한 엘리먼트를 찾아내고, 해당 엘리먼트와 움직이는 엘리먼트 사이의 오버랩되는 부분을 이용한 간단한 드래그 앤 드랍. 

기능적으로는 정상적으로 작동하나,  애니메이션 및 기타 효과를 통해 UX의 향상이 필요함

## eventDelegation

이벤트의 버블링/캡쳐링의 전파 효과를 이용해서, 전역 객체인 `window`에 이벤트 리스너 하나만을 등록하고, 해당 이벤트 리스너에서 이벤트가 발생해야 하는 타겟을 찾아 이벤트를 발생시키는 방법

dran and drop 구현과정에서도 실제 움직이는 것은 각각의 `item`컴포넌트이지만, pointermove, pointerup, pointerdown 등의 이벤트는 `window`객체에 걸어두고 `e.target.closest('.item-wrapper)`라는 가장 가까운 엘리먼트를 찾는 셀렉터를 통해서 실제 이벤트가 작동시킴